### PR TITLE
Stop room assistant

### DIFF
--- a/roles/clients/tasks/main.yml
+++ b/roles/clients/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Stop room-assistant service
+  become: yes
+  systemd:
+    name: room-assistant
+    state: stopped
+  ignore_errors: True

--- a/room-assistant.yml
+++ b/room-assistant.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: all
   roles:
+    - clients
     - nodejs
     - room-assistant


### PR DESCRIPTION
This PR adds an initial step of stopping all currently running room-assistant services.

This is especially important in light of [this issue](https://github.com/mKeRix/ansible-playbooks/issues/6) where ansible-playbooks failed if network requests were inhibited by over-active bluetooth searches.

Shutting down the service first ensures that full network throughput is available on a device where wifi and bluetooth are on the one chip.